### PR TITLE
Remove use of $.browser from gfx initialization

### DIFF
--- a/lib/gfx.js
+++ b/lib/gfx.js
@@ -12,9 +12,7 @@
     return 'transition' in style || 'webkitTransition' in style || 'MozTransition' in style;
   })());
 
-  vendor = $.browser.mozilla ? 'moz' : void 0;
-
-  vendor || (vendor = 'webkit');
+  vendor = navigator.userAgent.indexOf('Firefox') > -1 ? 'moz' : 'webkit';
 
   prefix = "-" + vendor + "-";
 

--- a/src/gfx.coffee
+++ b/src/gfx.coffee
@@ -8,8 +8,7 @@ $.support.transition or= do ->
    'webkitTransition' of style or
     'MozTransition' of style
 
-vendor = if $.browser.mozilla then 'moz'
-vendor or= 'webkit'
+vendor = if navigator.userAgent.indexOf('Firefox') > -1 then 'moz' else 'webkit'
 prefix = "-#{vendor}-"
 
 vendorNames = n =


### PR DESCRIPTION
$.browser has been removed as of JQuery 1.9 (http://jquery.com/upgrade-guide/1.9/#jquery-browser-removed). This fix replaces use of $.browser with navigator.userAgent detection to determine if the browser is WebKit or Firefox.
